### PR TITLE
Integration to list tasks in backlog page

### DIFF
--- a/backend/src/mappers/composite/taskselfcomposite.mapper.ts
+++ b/backend/src/mappers/composite/taskselfcomposite.mapper.ts
@@ -8,7 +8,9 @@ export function mapTaskSelfComposite(task: any, projectCode: string): TaskSelfCo
 		responsibleEid: encryptPK("user", task.dataValues.assignedTo),
 		code: `${projectCode}-TSK-${task.dataValues.index}`,
 		title: task.dataValues.title,
+		description: task.dataValues.description,
 		status: task.dataValues.etaskstatusId,
 		type: task.dataValues.etasktypeId,
+		createdAt: task.dataValues.createdAt,
 	};
 }

--- a/frontend/src/app/core/components/pages/backlog-page/backlog-page.component.html
+++ b/frontend/src/app/core/components/pages/backlog-page/backlog-page.component.html
@@ -80,7 +80,7 @@
 						<ng-container matColumnDef="priority">
 							<th mat-header-cell *matHeaderCellDef>Priority</th>
 							<td mat-cell *matCellDef="let element">
-								<img [src]="priorityParser(element.priority)" />
+								<img [src]="priorityParserString(element.priority)" />
 							</td>
 						</ng-container>
 
@@ -136,6 +136,62 @@
 								<button class="green-button" (click)="openPopUpAddToSprint()">Add to a sprint</button>
 							</mat-panel-description>
 						</mat-expansion-panel-header>
+						@if (getTasksDataSource(userstory.eid).data.length > 0) {
+							<table
+								mat-table
+								[dataSource]="getTasksDataSource(userstory.eid)"
+								matSort
+								class="mat-elevation-z8 history-table"
+							>
+								<ng-container matColumnDef="type">
+									<th mat-header-cell *matHeaderCellDef mat-sort-header>Issue</th>
+									<td #itemCell mat-cell *matCellDef="let element">{{ typeParser(element.type) }}</td>
+								</ng-container>
+
+								<ng-container matColumnDef="key">
+									<th mat-header-cell *matHeaderCellDef>Key</th>
+									<td mat-cell *matCellDef="let element">{{ element.code }}</td>
+								</ng-container>
+
+								<ng-container matColumnDef="subject">
+									<th mat-header-cell *matHeaderCellDef>Subject</th>
+									<td mat-cell *matCellDef="let element">{{ element.description }}</td>
+								</ng-container>
+
+								<ng-container matColumnDef="status">
+									<th mat-header-cell *matHeaderCellDef>Status</th>
+									<td mat-cell *matCellDef="let element">
+										<div #statusContainer class="status-container">
+											{{ statusParser(element.status) }}
+										</div>
+									</td>
+								</ng-container>
+
+								<ng-container matColumnDef="assignee">
+									<th mat-header-cell *matHeaderCellDef>Responsible</th>
+									<td mat-cell *matCellDef="let element">
+										<div class="assignee-container">
+											<img src="{{ getProjectMemberFromMap(element.responsibleEid)?.gravatar }}" />
+											<p>{{ getProjectMemberFromMap(element.responsibleEid)?.name }}</p>
+										</div>
+									</td>
+								</ng-container>
+
+								<ng-container matColumnDef="priority">
+									<th mat-header-cell *matHeaderCellDef>Priority</th>
+									<td mat-cell *matCellDef="let element">
+										<img [src]="priorityParser(userstory.priority)" />
+									</td>
+								</ng-container>
+
+								<ng-container matColumnDef="created">
+									<th mat-header-cell *matHeaderCellDef>Created</th>
+									<td mat-cell *matCellDef="let element">{{ element.createdAt | date }}</td>
+								</ng-container>
+								<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+								<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+							</table>
+						}
 					</mat-expansion-panel>
 				}
 			</mat-accordion>
@@ -197,7 +253,7 @@
 			<div class="info priority">
 				<p>Priority:</p>
 				<div class="content">
-					<img [src]="priorityParser(clickedItemDetails.priority)" />
+					<img [src]="priorityParserString(clickedItemDetails.priority)" />
 					<span>{{ clickedItemDetails.priority }}</span>
 				</div>
 			</div>

--- a/frontend/src/app/core/components/pages/backlog-page/backlog-page.component.scss
+++ b/frontend/src/app/core/components/pages/backlog-page/backlog-page.component.scss
@@ -124,6 +124,8 @@ app-navbar {
 
 						& > img {
 							margin-right: 6px;
+							border-radius: 50%;
+							width: 16px;
 						}
 
 						& > p {

--- a/frontend/src/app/core/components/pages/epic-page/epics-page.component.html
+++ b/frontend/src/app/core/components/pages/epic-page/epics-page.component.html
@@ -47,34 +47,34 @@
 								<mat-icon (click)="openPopUpDeleteEpic(epic.eid)">delete</mat-icon>
 							</mat-panel-description>
 						</mat-expansion-panel-header>
+						@if (getUserStoriesDataSource(epic.eid).data.length > 0) {
+							<table mat-table [dataSource]="getUserStoriesDataSource(epic.eid)" class="epics-table">
+								<ng-container matColumnDef="key">
+									<th mat-header-cell *matHeaderCellDef>Key</th>
+									<td mat-cell *matCellDef="let story">{{ story.code }}</td>
+								</ng-container>
 
-						<table mat-table [dataSource]="getUserStoriesDataSource(epic.eid)" class="epics-table">
-							<ng-container matColumnDef="key">
-								<th mat-header-cell *matHeaderCellDef>Key</th>
-								<td mat-cell *matCellDef="let story">{{ story.code }}</td>
-							</ng-container>
+								<ng-container matColumnDef="title">
+									<th mat-header-cell *matHeaderCellDef>History</th>
+									<td mat-cell *matCellDef="let story">{{ story.title }}</td>
+								</ng-container>
 
-							<ng-container matColumnDef="title">
-								<th mat-header-cell *matHeaderCellDef>History</th>
-								<td mat-cell *matCellDef="let story">{{ story.title }}</td>
-							</ng-container>
+								<ng-container matColumnDef="description">
+									<th mat-header-cell *matHeaderCellDef>Description</th>
+									<td mat-cell *matCellDef="let story">{{ story.description }}</td>
+								</ng-container>
 
-							<ng-container matColumnDef="description">
-								<th mat-header-cell *matHeaderCellDef>Description</th>
-								<td mat-cell *matCellDef="let story">{{ story.description }}</td>
-							</ng-container>
+								<ng-container matColumnDef="priority">
+									<th mat-header-cell *matHeaderCellDef>Priority</th>
+									<td mat-cell *matCellDef="let story">
+										<img src="{{ priorityParser(story.priority) }}" alt="{{ story.priority }} priority" />
+									</td>
+								</ng-container>
 
-							<ng-container matColumnDef="priority">
-								<th mat-header-cell *matHeaderCellDef>Priority</th>
-								<td mat-cell *matCellDef="let story">
-									<img src="{{ priorityParser(story.priority) }}" alt="{{ story.priority }} priority" />
-								</td>
-							</ng-container>
-
-							<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-							<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-						</table>
-						<div class="add-issue" (click)="openPopUpIssue(epic.eid)">+ Add another issue</div>
+								<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+								<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+							</table>
+						}
 					</mat-expansion-panel>
 				}
 			</mat-accordion>

--- a/frontend/src/app/core/components/pages/epic-page/epics-page.component.ts
+++ b/frontend/src/app/core/components/pages/epic-page/epics-page.component.ts
@@ -83,7 +83,9 @@ export class EpicsPageComponent implements OnInit {
 				);
 
 				return combineLatest(userStoriesObservables).pipe(
-					map((userStoriesArray) => userStoriesArray.reduce((acc, curr) => ({ ...acc, ...curr }), {})),
+					map((userStoriesArray) =>
+						userStoriesArray.filter((entry) => entry !== null).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
+					),
 				);
 			}),
 			shareReplay(1),

--- a/frontend/src/app/core/services/task-api.service.ts
+++ b/frontend/src/app/core/services/task-api.service.ts
@@ -1,0 +1,19 @@
+import { ApiService } from "./api.service";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { TaskSelfResponse } from "forge-shared/dto/response/taskselfresponse.dto";
+
+@Injectable({
+	providedIn: "root",
+})
+export class TaskApiService {
+	constructor(private apiService: ApiService) {}
+
+	public getTasks(projectEid: string, userStoryEid: string): Observable<TaskSelfResponse> {
+		return this.apiService.call<TaskSelfResponse>("GET", `task/${projectEid}/${userStoryEid}/self`);
+	}
+
+	public task(projectEid: string, userStoryEid: string): Observable<TaskSelfResponse> {
+		return this.apiService.call<TaskSelfResponse>("GET", `task/${projectEid}/${userStoryEid}/get`);
+	}
+}

--- a/shared/dto/composite/taskselfcomposite.dto.ts
+++ b/shared/dto/composite/taskselfcomposite.dto.ts
@@ -19,10 +19,15 @@ import { TaskType } from "../../enum/tasktype.enum";
  *           type: string
  *         title:
  *           type: string
+ *         description:
+ *           type: string
  *         status:
  *           $ref: '#/components/schemas/TaskStatus'
  *         type:
  *           $ref: '#/components/schemas/TaskType'
+ *         createdAt:
+ *           type: string
+ *           format: date-time
  */
 export interface TaskSelfComposite {
 	eid: string;
@@ -30,6 +35,8 @@ export interface TaskSelfComposite {
 	responsibleEid?: string;
 	code: string;
 	title: string;
+	description: string;
 	status: TaskStatus;
 	type: TaskType;
+	createdAt: string;
 }


### PR DESCRIPTION
- Created the task api service

- Added 2 new attributes in the taskselfcomposite dto (description and createdAt)

- To list the tasks, I have used the same approach as in the epics page to list the userstories in that page.

- Fixed an issue in the tables: added a verification both in epics page and backlog page to just display the table for the elements (userstory and task respectively) if the datasource has data.